### PR TITLE
fix: handle dict debate_mode config in EnsembleDecisionManager

### DIFF
--- a/finance_feedback_engine/core.py
+++ b/finance_feedback_engine/core.py
@@ -1768,6 +1768,13 @@ class FinanceFeedbackEngine:
         signal-only blocking (deprecated in favor of explicit approvals/autonomous mode).
         """
 
+        # Block signal-only decisions from execution
+        if decision.get("signal_only"):
+            raise ValueError(
+                "Cannot execute trade in signal-only mode. "
+                "Decision is flagged as signal_only."
+            )
+
         # Note: Leverage and concentration checks are now handled by
         # RiskGatekeeper._validate_leverage_and_concentration() which is called
         # during the agent RISK_CHECK state. This consolidates all risk validation

--- a/finance_feedback_engine/decision_engine/ensemble_manager.py
+++ b/finance_feedback_engine/decision_engine/ensemble_manager.py
@@ -119,7 +119,8 @@ class EnsembleDecisionManager:
         self.learning_rate = ensemble_config.get("learning_rate", 0.1)
 
         # Debate mode settings
-        self.debate_mode = ensemble_config.get("debate_mode", False)
+        raw_debate = ensemble_config.get("debate_mode", False)
+        self.debate_mode = raw_debate.get("enabled", False) if isinstance(raw_debate, dict) else bool(raw_debate)
 
         # THR-63: Use curated debate seat resolver (prefers local Ollama models with cloud fallback)
         if self.debate_mode:

--- a/tests/test_core_execution.py
+++ b/tests/test_core_execution.py
@@ -44,7 +44,7 @@ def minimal_config(tmp_path):
             "enabled_providers": ["local"],
             "provider_weights": {"local": 1.0},
             "min_providers_required": 1,
-            "debate_mode": {"enabled": False},
+            "debate_mode": False,
         },
         "decision_engine": {
             "signal_only_default": False,


### PR DESCRIPTION
Fixes 21 pre-existing test failures in `test_core_execution.py`.

### Root Cause
`debate_mode` was passed as `{"enabled": False}` (a dict) in test fixtures and config. `EnsembleDecisionManager` assigned this directly to `self.debate_mode`, and since a non-empty dict is truthy in Python, it triggered debate provider validation — which then failed because `gemini`/`qwen` weren't in `enabled_providers: ["local"]`.

### Fixes
1. **`ensemble_manager.py`**: Extract `enabled` key when `debate_mode` is a dict
2. **`test_core_execution.py`**: Fixed fixture to pass `debate_mode: False` (bool, not dict)
3. **`core.py`**: Restored signal-only blocking in `_preexecution_checks()`

### Test Results
- ✅ All 22 tests in `test_core_execution.py` pass
- ✅ All 61 `tests/risk/` tests pass (no regressions)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added validation to prevent trade execution when operating in signal-only mode, ensuring analysis-only operations remain safe

* **Improvements**
  * Enhanced debate mode configuration to support both boolean and structured format settings for greater flexibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->