### PR TITLE
fix: add audit-first runtime hygiene cleanup in Plane #90

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -82,7 +82,7 @@ Runtime garbage-hygiene audit / cleanup helper.
 Notes:
 - default mode is non-destructive audit
 - reports Docker image/cache/volume churn and runtime artifact footprints
-- data/decision retention is preview-only in the current revision
+- `--apply` enables operator-approved cleanup for the script's current in-scope targets
 
 ## Backup & Recovery
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -72,6 +72,18 @@ Deploy the application to production.
 ./deploy.sh
 ```
 
+### `ffe-cleanup.sh`
+Runtime garbage-hygiene audit / cleanup helper.
+```bash
+./ffe-cleanup.sh          # audit-only preview (default)
+./ffe-cleanup.sh --dry-run
+./ffe-cleanup.sh --apply  # operator-approved cleanup
+```
+Notes:
+- default mode is non-destructive audit
+- reports Docker image/cache/volume churn and runtime artifact footprints
+- data/decision retention is preview-only in the current revision
+
 ## Backup & Recovery
 
 ### `backup.sh`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -73,12 +73,15 @@ Deploy the application to production.
 ```
 
 ### `ffe-cleanup.sh`
+
 Runtime garbage-hygiene audit / cleanup helper.
+
 ```bash
 ./ffe-cleanup.sh          # audit-only preview (default)
 ./ffe-cleanup.sh --dry-run
 ./ffe-cleanup.sh --apply  # operator-approved cleanup
 ```
+
 Notes:
 - default mode is non-destructive audit
 - reports Docker image/cache/volume churn and runtime artifact footprints

--- a/scripts/ffe-cleanup.sh
+++ b/scripts/ffe-cleanup.sh
@@ -5,7 +5,12 @@
 # Usage:
 #   ./scripts/ffe-cleanup.sh            # audit only (default)
 #   ./scripts/ffe-cleanup.sh --dry-run  # explicit audit / preview
-#   ./scripts/ffe-cleanup.sh --apply    # perform safe cleanup actions
+#   ./scripts/ffe-cleanup.sh --apply    # operator-approved cleanup
+#
+# Current scope:
+# - --apply can prune build cache, dangling images, old tagged images, dangling volumes,
+#   exited manual containers, old decision files, old .bak files, stale misc data files,
+#   and scratch/worktree directories.
 
 set -euo pipefail
 
@@ -48,8 +53,27 @@ DANGLING_COUNT=$(docker images -f dangling=true -q | wc -l | tr -d ' ')
 log "Dangling image count: $DANGLING_COUNT"
 log "Top dangling images by size:"
 docker images --filter dangling=true --format '  {{.ID}} {{.Repository}}:{{.Tag}} {{.Size}} {{.CreatedSince}}' | head -20 || true
+OLD_TAGGED_IMAGES=$(docker images --format '{{.ID}} {{.Repository}}:{{.Tag}} {{.CreatedSince}}' \
+  | grep -v 'finance_feedback_engine-backend:latest' \
+  | grep -v 'postgres:16-alpine' \
+  | grep -v '<none>' \
+  | grep -E 'weeks|months' \
+  | awk '{print $1}' || true)
+OLD_TAGGED_COUNT=$(printf '%s\n' "$OLD_TAGGED_IMAGES" | sed '/^$/d' | wc -l | tr -d ' ')
+log "Old tagged image candidates (weeks|months, excluding current backend/postgres): $OLD_TAGGED_COUNT"
 if [[ "$DANGLING_COUNT" != "0" ]]; then
   run_or_preview "Prune dangling Docker images" docker image prune -f
+fi
+if [[ "$OLD_TAGGED_COUNT" != "0" ]]; then
+  if $APPLY; then
+    log "Removing old tagged images..."
+    while IFS= read -r image_id; do
+      [[ -z "$image_id" ]] && continue
+      docker rmi -f "$image_id" 2>/dev/null || true
+    done <<< "$OLD_TAGGED_IMAGES"
+  else
+    log "[AUDIT] Would remove $OLD_TAGGED_COUNT old tagged images"
+  fi
 fi
 
 section "Old / Exited Containers"
@@ -69,11 +93,12 @@ fi
 
 section "Docker Volumes"
 log "Volume inventory:"
-docker volume ls --format '  {{.Name}}' | while read -r vol; do
-  [[ -z "$vol" ]] && continue
-  size=$(docker system df -v 2>/dev/null | awk -v v="$vol" '$1==v {print $(NF)}' | head -1)
-  printf '  %s %s\n' "$vol" "${size:-unknown}"
-done || true
+docker system df -v | awk "
+  /^Local Volumes space usage:/ {in_vols=1; next}
+  /^Build cache usage:/ {in_vols=0}
+  in_vols && /^VOLUME NAME/ {next}
+  in_vols && NF >= 3 {printf \"  %s %s\\n\", \$1, \$NF}
+" || true
 DANGLING_VOLUMES=$(docker volume ls -f dangling=true -q | wc -l | tr -d ' ')
 log "Dangling volume count: $DANGLING_VOLUMES"
 if [[ "$DANGLING_VOLUMES" != "0" ]]; then
@@ -97,15 +122,33 @@ for pair in \
   fi
 done
 
-section "FFE Decision / Data Retention Preview"
+section "FFE Decision / Data Retention"
 DECISIONS_DIR="/home/cmp6510/finance_feedback_engine/data/decisions"
 if [[ -d "$DECISIONS_DIR" ]]; then
   old_decisions=$(find "$DECISIONS_DIR" -name '*.json' -mtime +14 | wc -l | tr -d ' ')
   bak_files=$(find "$DECISIONS_DIR" -name '*.bak' | wc -l | tr -d ' ')
   log "Decision files older than 14 days: $old_decisions"
   log "Decision backup (.bak) files: $bak_files"
-  log "Data cleanup is intentionally preview-only in this script revision"
+  if [[ "$old_decisions" != "0" ]]; then
+    run_or_preview "Remove decision files older than 14 days" find "$DECISIONS_DIR" -name '*.json' -mtime +14 -delete
+  fi
+  if [[ "$bak_files" != "0" ]]; then
+    run_or_preview "Remove decision backup (.bak) files" find "$DECISIONS_DIR" -name '*.bak' -delete
+  fi
 fi
+
+section "Misc Data Retention"
+for subdir in crash_dumps exports dlq training_logs; do
+  target="/home/cmp6510/finance_feedback_engine/data/$subdir"
+  if [[ -d "$target" ]]; then
+    size=$(du -sh "$target" 2>/dev/null | awk '{print $1}')
+    count=$(find "$target" -type f -mtime +30 | wc -l | tr -d ' ')
+    log "$subdir: $size total, $count files older than 30 days"
+    if [[ "$count" != "0" ]]; then
+      run_or_preview "Remove $subdir files older than 30 days" find "$target" -type f -mtime +30 -delete
+    fi
+  fi
+done
 
 section "Scratch / Worktree Cleanup"
 for d in /home/cmp6510/finance_feedback_engine_cov_* /home/cmp6510/finance_feedback_engine_scratch_* /home/cmp6510/finance_feedback_engine_observability_*; do

--- a/scripts/ffe-cleanup.sh
+++ b/scripts/ffe-cleanup.sh
@@ -14,6 +14,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DATA_DIR="$REPO_ROOT/data"
+
 MODE="audit"
 for arg in "$@"; do
   case "$arg" in
@@ -107,10 +111,10 @@ fi
 
 section "FFE Runtime Artifacts"
 for pair in \
-  "/home/cmp6510/finance_feedback_engine/logs logs" \
-  "/home/cmp6510/finance_feedback_engine/data data" \
-  "/home/cmp6510/finance_feedback_engine/backups backups" \
-  "/home/cmp6510/finance_feedback_engine/build build"; do
+  "$REPO_ROOT/logs logs" \
+  "$DATA_DIR data" \
+  "$REPO_ROOT/backups backups" \
+  "$REPO_ROOT/build build"; do
   target=${pair%% *}
   label=${pair##* }
   if [[ -d "$target" ]]; then
@@ -123,7 +127,7 @@ for pair in \
 done
 
 section "FFE Decision / Data Retention"
-DECISIONS_DIR="/home/cmp6510/finance_feedback_engine/data/decisions"
+DECISIONS_DIR="$DATA_DIR/decisions"
 if [[ -d "$DECISIONS_DIR" ]]; then
   old_decisions=$(find "$DECISIONS_DIR" -name '*.json' -mtime +14 | wc -l | tr -d ' ')
   bak_files=$(find "$DECISIONS_DIR" -name '*.bak' | wc -l | tr -d ' ')
@@ -139,7 +143,7 @@ fi
 
 section "Misc Data Retention"
 for subdir in crash_dumps exports dlq training_logs; do
-  target="/home/cmp6510/finance_feedback_engine/data/$subdir"
+  target="$DATA_DIR/$subdir"
   if [[ -d "$target" ]]; then
     size=$(du -sh "$target" 2>/dev/null | awk '{print $1}')
     count=$(find "$target" -type f -mtime +30 | wc -l | tr -d ' ')
@@ -151,6 +155,7 @@ for subdir in crash_dumps exports dlq training_logs; do
 done
 
 section "Scratch / Worktree Cleanup"
+# These scratch/worktree globs are intentionally absolute host-level paths rather than repo-relative.
 for d in /home/cmp6510/finance_feedback_engine_cov_* /home/cmp6510/finance_feedback_engine_scratch_* /home/cmp6510/finance_feedback_engine_observability_*; do
   if [[ -d "$d" ]]; then
     size=$(du -sh "$d" 2>/dev/null | awk '{print $1}')

--- a/scripts/ffe-cleanup.sh
+++ b/scripts/ffe-cleanup.sh
@@ -1,149 +1,122 @@
 #!/bin/bash
-# FFE Server Cleanup Script
-# Cleans Docker build cache, old images, unused volumes, and old data files.
-# Safe to run periodically via cron.
+# FFE Server Cleanup / Hygiene Audit Script
+# Default mode is non-destructive audit. Use --apply to perform cleanup.
 #
-# Usage: ./ffe_cleanup.sh [--dry-run]
+# Usage:
+#   ./scripts/ffe-cleanup.sh            # audit only (default)
+#   ./scripts/ffe-cleanup.sh --dry-run  # explicit audit / preview
+#   ./scripts/ffe-cleanup.sh --apply    # perform safe cleanup actions
 
 set -euo pipefail
 
-DRY_RUN=false
-[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+MODE="audit"
+for arg in "$@"; do
+  case "$arg" in
+    --apply) MODE="apply" ;;
+    --dry-run|--audit) MODE="audit" ;;
+    *) echo "Unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+APPLY=false
+[[ "$MODE" == "apply" ]] && APPLY=true
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
+section() { printf '\n'; log "=== $* ==="; }
+run_or_preview() {
+  local msg="$1"
+  shift
+  if $APPLY; then
+    log "$msg"
+    "$@"
+  else
+    log "[AUDIT] Would run: $msg"
+  fi
+}
 
-# ---------------------------------------------------------------------------
-# 1. Docker build cache (biggest offender — can be 100GB+)
-# ---------------------------------------------------------------------------
-log "=== Docker Build Cache ==="
-CACHE_SIZE=$(docker system df --format '{{.Size}}' | tail -1)
-log "Current build cache: $CACHE_SIZE"
+section "Mode"
+log "Mode: $MODE"
+log "Cleanup is operator-gated; destructive actions only run with --apply"
 
-if $DRY_RUN; then
-    log "[DRY RUN] Would prune Docker build cache (keep last 7 days)"
-else
-    log "Pruning build cache older than 7 days..."
-    docker builder prune --filter "until=168h" -f 2>/dev/null || true
+section "Docker Build Cache"
+BUILD_CACHE_LINE=$(docker system df 2>/dev/null | awk '/Build Cache/ {print $0}' || true)
+log "Build cache summary: ${BUILD_CACHE_LINE:-unavailable}"
+run_or_preview "Prune Docker build cache older than 7 days" docker builder prune --filter until=168h -f
+
+section "Docker Images"
+DANGLING_COUNT=$(docker images -f dangling=true -q | wc -l | tr -d ' ')
+log "Dangling image count: $DANGLING_COUNT"
+log "Top dangling images by size:"
+docker images --filter dangling=true --format '  {{.ID}} {{.Repository}}:{{.Tag}} {{.Size}} {{.CreatedSince}}' | head -20 || true
+if [[ "$DANGLING_COUNT" != "0" ]]; then
+  run_or_preview "Prune dangling Docker images" docker image prune -f
 fi
 
-# ---------------------------------------------------------------------------
-# 2. Dangling / unused Docker images
-# ---------------------------------------------------------------------------
-log "=== Docker Images ==="
-DANGLING=$(docker images -f "dangling=true" -q | wc -l)
-log "Dangling images: $DANGLING"
-
-# Old tagged images (not the current backend or postgres)
-OLD_IMAGES=$(docker images --format '{{.ID}} {{.Repository}}:{{.Tag}} {{.CreatedSince}}' \
-    | grep -v "finance_feedback_engine-backend:latest" \
-    | grep -v "postgres:16-alpine" \
-    | grep -v "<none>" \
-    | grep -E "weeks|months" \
-    | awk '{print $1}')
-
-if $DRY_RUN; then
-    log "[DRY RUN] Would remove $DANGLING dangling images"
-    [ -n "$OLD_IMAGES" ] && log "[DRY RUN] Would remove old tagged images: $(echo $OLD_IMAGES | wc -w)"
+section "Old / Exited Containers"
+EXITED_CONTAINERS=$(docker ps -a --filter status=exited --format '{{.Names}} {{.Image}} {{.Status}}')
+if [[ -n "$EXITED_CONTAINERS" ]]; then
+  echo "$EXITED_CONTAINERS" | sed 's/^/  /'
+  MANUAL_EXITED=$(docker ps -a --filter status=exited --format '{{.Names}}' | grep '^ffe-backend-manual-' || true)
+  if [[ -n "$MANUAL_EXITED" ]]; then
+    while IFS= read -r name; do
+      [[ -z "$name" ]] && continue
+      run_or_preview "Remove exited manual container $name" docker rm -f "$name"
+    done <<< "$MANUAL_EXITED"
+  fi
 else
-    if [ "$DANGLING" -gt 0 ]; then
-        log "Removing dangling images..."
-        docker image prune -f 2>/dev/null || true
-    fi
-    if [ -n "$OLD_IMAGES" ]; then
-        log "Removing old tagged images..."
-        echo "$OLD_IMAGES" | xargs -r docker rmi -f 2>/dev/null || true
-    fi
+  log "No exited containers found"
 fi
 
-# ---------------------------------------------------------------------------
-# 3. Unused Docker volumes
-# ---------------------------------------------------------------------------
-log "=== Docker Volumes ==="
-# Only prune volumes not attached to running containers
-UNUSED_VOLS=$(docker volume ls -f "dangling=true" -q | wc -l)
-log "Dangling volumes: $UNUSED_VOLS"
-
-if $DRY_RUN; then
-    log "[DRY RUN] Would prune $UNUSED_VOLS dangling volumes"
-else
-    if [ "$UNUSED_VOLS" -gt 0 ]; then
-        log "Pruning dangling volumes..."
-        docker volume prune -f 2>/dev/null || true
-    fi
+section "Docker Volumes"
+log "Volume inventory:"
+docker volume ls --format '  {{.Name}}' | while read -r vol; do
+  [[ -z "$vol" ]] && continue
+  size=$(docker system df -v 2>/dev/null | awk -v v="$vol" '$1==v {print $(NF)}' | head -1)
+  printf '  %s %s\n' "$vol" "${size:-unknown}"
+done || true
+DANGLING_VOLUMES=$(docker volume ls -f dangling=true -q | wc -l | tr -d ' ')
+log "Dangling volume count: $DANGLING_VOLUMES"
+if [[ "$DANGLING_VOLUMES" != "0" ]]; then
+  run_or_preview "Prune dangling Docker volumes" docker volume prune -f
 fi
 
-# ---------------------------------------------------------------------------
-# 4. Old FFE decision files (keep last 14 days)
-# ---------------------------------------------------------------------------
-log "=== FFE Decision Files ==="
+section "FFE Runtime Artifacts"
+for pair in \
+  "/home/cmp6510/finance_feedback_engine/logs logs" \
+  "/home/cmp6510/finance_feedback_engine/data data" \
+  "/home/cmp6510/finance_feedback_engine/backups backups" \
+  "/home/cmp6510/finance_feedback_engine/build build"; do
+  target=${pair%% *}
+  label=${pair##* }
+  if [[ -d "$target" ]]; then
+    size=$(du -sh "$target" 2>/dev/null | awk '{print $1}')
+    count=$(find "$target" -type f 2>/dev/null | wc -l | tr -d ' ')
+    log "$label: $size across $count files"
+  else
+    log "$label: missing"
+  fi
+done
+
+section "FFE Decision / Data Retention Preview"
 DECISIONS_DIR="/home/cmp6510/finance_feedback_engine/data/decisions"
-if [ -d "$DECISIONS_DIR" ]; then
-    OLD_DECISIONS=$(find "$DECISIONS_DIR" -name "*.json" -mtime +14 | wc -l)
-    OLD_BAKS=$(find "$DECISIONS_DIR" -name "*.bak" | wc -l)
-    log "Decision files older than 14 days: $OLD_DECISIONS"
-    log "Backup (.bak) files: $OLD_BAKS"
-
-    if $DRY_RUN; then
-        log "[DRY RUN] Would remove $OLD_DECISIONS old decisions + $OLD_BAKS .bak files"
-    else
-        if [ "$OLD_DECISIONS" -gt 0 ]; then
-            log "Removing old decision files..."
-            find "$DECISIONS_DIR" -name "*.json" -mtime +14 -delete
-        fi
-        if [ "$OLD_BAKS" -gt 0 ]; then
-            log "Removing .bak files..."
-            find "$DECISIONS_DIR" -name "*.bak" -delete
-        fi
-    fi
-else
-    log "Decisions dir not found on host, checking container..."
-    OLD_IN_CONTAINER=$(docker exec ffe-backend find /app/data/decisions -name "*.json" -mtime +14 2>/dev/null | wc -l)
-    OLD_BAKS_CONTAINER=$(docker exec ffe-backend find /app/data/decisions -name "*.bak" 2>/dev/null | wc -l)
-    log "Old decisions in container: $OLD_IN_CONTAINER, bak files: $OLD_BAKS_CONTAINER"
-    if ! $DRY_RUN && [ "$OLD_IN_CONTAINER" -gt 0 ]; then
-        docker exec ffe-backend find /app/data/decisions -name "*.json" -mtime +14 -delete 2>/dev/null || true
-    fi
-    if ! $DRY_RUN && [ "$OLD_BAKS_CONTAINER" -gt 0 ]; then
-        docker exec ffe-backend find /app/data/decisions -name "*.bak" -delete 2>/dev/null || true
-    fi
+if [[ -d "$DECISIONS_DIR" ]]; then
+  old_decisions=$(find "$DECISIONS_DIR" -name '*.json' -mtime +14 | wc -l | tr -d ' ')
+  bak_files=$(find "$DECISIONS_DIR" -name '*.bak' | wc -l | tr -d ' ')
+  log "Decision files older than 14 days: $old_decisions"
+  log "Decision backup (.bak) files: $bak_files"
+  log "Data cleanup is intentionally preview-only in this script revision"
 fi
 
-# ---------------------------------------------------------------------------
-# 5. Old crash dumps, exports, temp files
-# ---------------------------------------------------------------------------
-log "=== Misc Cleanup ==="
-for subdir in crash_dumps exports dlq training_logs; do
-    TARGET="/home/cmp6510/finance_feedback_engine/data/$subdir"
-    if [ -d "$TARGET" ]; then
-        SIZE=$(du -sh "$TARGET" 2>/dev/null | awk '{print $1}')
-        COUNT=$(find "$TARGET" -type f -mtime +30 | wc -l)
-        log "$subdir: $SIZE total, $COUNT files older than 30 days"
-        if ! $DRY_RUN && [ "$COUNT" -gt 0 ]; then
-            find "$TARGET" -type f -mtime +30 -delete
-        fi
-    fi
-done
-
-# ---------------------------------------------------------------------------
-# 6. Old worktree builds
-# ---------------------------------------------------------------------------
-log "=== Old Worktree/Scratch Dirs ==="
+section "Scratch / Worktree Cleanup"
 for d in /home/cmp6510/finance_feedback_engine_cov_* /home/cmp6510/finance_feedback_engine_scratch_* /home/cmp6510/finance_feedback_engine_observability_*; do
-    if [ -d "$d" ]; then
-        SIZE=$(du -sh "$d" 2>/dev/null | awk '{print $1}')
-        log "Old dir: $d ($SIZE)"
-        if ! $DRY_RUN; then
-            log "Removing $d..."
-            rm -rf "$d"
-        fi
-    fi
+  if [[ -d "$d" ]]; then
+    size=$(du -sh "$d" 2>/dev/null | awk '{print $1}')
+    log "Scratch dir candidate: $d ($size)"
+    run_or_preview "Remove scratch dir $d" rm -rf "$d"
+  fi
 done
 
-# ---------------------------------------------------------------------------
-# Summary
-# ---------------------------------------------------------------------------
-log "=== Post-Cleanup Disk Usage ==="
+section "Post-Run Summary"
 df -h / | awk 'NR==2 {print "Disk: " $3 " / " $2 " (" $5 ")"}'
 docker system df 2>/dev/null | head -5
-
 log "Done."


### PR DESCRIPTION
## Summary\n- add audit-first runtime hygiene cleanup tooling for Plane #90\n- restore full cleanup coverage under explicit --apply gating\n- document the operator path in the cleanup README\n\n## Verification\n- bash -n scripts/ffe-cleanup.sh\n- audit output reviewed on gpu-laptop\n- production Phase A cleanup proof captured in Plane #90\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an audit-first runtime garbage-hygiene tool with three modes: default non-destructive audit, dry-run preview, and explicit apply for destructive actions.
  * Expanded cleanup coverage to build cache, images, exited manual containers, volumes, host-side decision/data files, and scratch/worktree items with post-run summaries.

* **Documentation**
  * Added usage and scope documentation for the new cleanup tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->