### PR TITLE
ci: split test suite into fast-lane (merge gate) and slow-lane (nightly) — Plane #95 / GitHub #88

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ env:
   ENVIRONMENT: ci
 
 jobs:
-  # Keep the required gate intentionally small and stable.
-  backend-quality:
-    name: Backend quality + tests
+  # Required merge gate: fast, stable subset plus Tier 2 xfail manifest.
+  tests-fast:
+    name: tests-fast
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -36,10 +36,41 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
-      - name: Pytest
+      - name: Run fast-lane tests
         run: |
           pytest --full-suite \
             -m "not external_service and not slow and not benchmark" \
+            --ignore=tests/integration/test_trading_api_endpoints.py \
+            --ignore=tests/test_api_endpoints.py \
+            --ignore=tests/test_bot_control_auth.py \
+            --ignore=tests/test_websocket_auth.py \
+            --ignore=tests/agent/test_trading_loop_reasoning_parallelization.py \
+            --ignore=tests/decision_engine/test_ai_decision_manager_policy_actions.py \
+            --ignore=tests/test_bug_fixes.py \
+            --ignore=tests/test_coinbase_platform_comprehensive.py \
+            --ignore=tests/test_config_editor_telegram_validation.py \
+            --ignore=tests/test_core_additional.py \
+            --ignore=tests/test_core_execution.py \
+            --ignore=tests/test_core_integration.py \
+            --ignore=tests/test_core_trading_flow_integration.py \
+            --ignore=tests/test_critical_fixes_integration.py \
+            --ignore=tests/test_exception_handling_fixes.py \
+            --ignore=tests/test_execute_safety.py \
+            --ignore=tests/test_phase2_performance_benchmarks.py \
+            --ignore=tests/test_portfolio_memory_persistence.py \
+            --ignore=tests/test_provider_tiers.py \
+            --ignore=tests/test_short_position_state_awareness.py \
+            --ignore=tests/test_trading_loop_agent.py \
+            --ignore=tests/test_trading_loop_agent_comprehensive.py \
+            --ignore=tests/test_observability_integration.py \
+            --ignore=tests/test_cli_smoke.py \
+            --ignore=tests/test_long_running_stability.py \
+            --ignore=tests/test_real_market_data_integration.py \
+            -n auto \
+            -p no:randomly \
+            --timeout=60 \
+            --timeout-method=signal \
+            --tb=short \
             --cov=finance_feedback_engine \
             --cov-report=term-missing \
             --cov-report=xml \
@@ -52,3 +83,59 @@ jobs:
           name: coverage-xml
           path: coverage.xml
           retention-days: 14
+
+  # Non-blocking slow lane: quarantined structural failures and long-running tests.
+  tests-slow:
+    name: tests-slow
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run slow-lane tests
+        run: |
+          pytest \
+            tests/integration/test_trading_api_endpoints.py \
+            tests/test_api_endpoints.py \
+            tests/test_bot_control_auth.py \
+            tests/test_websocket_auth.py \
+            tests/agent/test_trading_loop_reasoning_parallelization.py \
+            tests/decision_engine/test_ai_decision_manager_policy_actions.py \
+            tests/test_bug_fixes.py \
+            tests/test_coinbase_platform_comprehensive.py \
+            tests/test_config_editor_telegram_validation.py \
+            tests/test_core_additional.py \
+            tests/test_core_execution.py \
+            tests/test_core_integration.py \
+            tests/test_core_trading_flow_integration.py \
+            tests/test_critical_fixes_integration.py \
+            tests/test_exception_handling_fixes.py \
+            tests/test_execute_safety.py \
+            tests/test_phase2_performance_benchmarks.py \
+            tests/test_portfolio_memory_persistence.py \
+            tests/test_provider_tiers.py \
+            tests/test_short_position_state_awareness.py \
+            tests/test_trading_loop_agent.py \
+            tests/test_trading_loop_agent_comprehensive.py \
+            tests/test_observability_integration.py \
+            tests/test_cli_smoke.py \
+            tests/test_long_running_stability.py \
+            tests/test_real_market_data_integration.py \
+            -p no:randomly \
+            --timeout=120 \
+            --timeout-method=signal \
+            --tb=short

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,7 @@ jobs:
             --tb=short \
             --cov=finance_feedback_engine \
             --cov-report=term-missing \
-            --cov-report=xml \
-            --cov-fail-under=70
+            --cov-report=xml
 
       - name: Upload coverage xml
         if: always()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ dev = [
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=5.0.0",
     "pytest-mock>=3.14.0",
+    "pytest-timeout>=2.3.1",
     "pytest-xdist>=3.5.0",
     "pytest-memray>=1.1.0",
     "memray>=1.11.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,25 @@ def pytest_configure(config):
     config.option.cov_fail_under = 0
 
 
+def pytest_collection_modifyitems(config, items):
+    """Apply non-strict xfail markers from tests/known_failing.txt."""
+    known_failing_path = config.rootpath / "tests" / "known_failing.txt"
+    if not known_failing_path.exists():
+        return
+
+    known_failures = {}
+    for raw_line in known_failing_path.read_text().splitlines():
+        nodeid, _, comment = raw_line.partition("#")
+        nodeid = nodeid.strip()
+        if nodeid:
+            known_failures[nodeid] = comment.strip()
+
+    for item in items:
+        if item.nodeid in known_failures:
+            reason = known_failures[item.nodeid] or "known fast-lane failure"
+            item.add_marker(pytest.mark.xfail(reason=reason, strict=False))
+
+
 # --- Logging Configuration Fixture ---
 # This fixture ensures all logging handlers are properly cleaned up after tests
 # to prevent "I/O operation on closed file" errors.

--- a/tests/decision_engine/test_debate_prompt_contracts.py
+++ b/tests/decision_engine/test_debate_prompt_contracts.py
@@ -393,7 +393,7 @@ Key Question: Should we adjust the existing long position given the overbought R
 
 
 def test_role_prompts_request_concise_reasoning_and_two_evidence_points():
-    source = Path('/home/cmp6510/finance_feedback_engine/finance_feedback_engine/decision_engine/ai_decision_manager.py').read_text()
+    source = (Path(__file__).resolve().parents[2] / 'finance_feedback_engine/decision_engine/ai_decision_manager.py').read_text()
 
     assert 'keeping each line short and concrete' in source
     assert 'Keep the total reasoning concise. Do not add extra sections or long prose.' in source

--- a/tests/decision_engine/test_local_llm_provider_policy_prompt.py
+++ b/tests/decision_engine/test_local_llm_provider_policy_prompt.py
@@ -1,4 +1,8 @@
+import pytest
+
 from finance_feedback_engine.decision_engine.local_llm_provider import LocalLLMProvider
+
+pytestmark = pytest.mark.external_service
 
 
 class DummyClient:

--- a/tests/known_failing.txt
+++ b/tests/known_failing.txt
@@ -1,0 +1,49 @@
+# Tier 2 known-failing tests — applied as xfail by tests/conftest.py hook.
+# Tracked under Plane FINANCEFEE-99. Remove a line as the test is fixed.
+# One nodeid per line. Lines starting with '#' or after '#' are comments.
+tests/agent/test_profit_readiness_gate.py::test_perception_halts_on_stale_data # cluster: stale-data/state transition
+tests/decision_engine/test_debate_fallback_gate.py::TestFallbackGateInDebateRole::test_legitimate_hold_not_rejected # cluster: debate/decision policy action compatibility
+tests/decision_engine/test_decision_validator_quality_scaling.py::test_decision_validator_policy_action_close_has_no_legacy_compatibility # cluster: debate/decision policy action compatibility
+tests/decision_engine/test_policy_actions.py::test_build_policy_selection_adaptive_control_exchange_response_handling_contract_set_preserves_multiple_exchange_http_transport_contract_summaries_in_order # cluster: debate/decision policy action compatibility
+tests/memory/test_integration.py::TestThompsonIntegration::test_provider_recommendations_updated # cluster: memory/time-window expectations
+tests/memory/test_performance_analyzer.py::TestPerformanceOverPeriod::test_performance_over_period_within_window # cluster: memory/time-window expectations
+tests/memory/test_thompson_integrator.py::TestGetProviderRecommendations::test_recommendations_based_on_win_rates # cluster: memory/time-window expectations
+tests/memory/test_trade_recorder.py::TestGetTradesInPeriod::test_get_trades_in_period # cluster: memory/time-window expectations
+tests/risk/test_gatekeeper_drawdown_normalization.py::test_gatekeeper_allows_futures_scale_in_when_margin_usage_implies_sub_limit_effective_leverage # cluster: risk/position sizing semantics
+tests/test_agent.py::test_agent_state_transitions # cluster: stale-data/state transition
+tests/test_api.py::test_get_balance # cluster: API/core drift
+tests/test_api.py::test_get_decision_history # cluster: API/core drift
+tests/test_bot_control_error_handling.py::test_get_open_positions_does_not_lie_with_zero_total_value_on_breakdown_error # cluster: known survey failure
+tests/test_bot_profitable_trade_integration.py::TestTradingBotProfitableTrade::test_bot_executes_profitable_trade # cluster: profitability/e2e expectation drift
+tests/test_cache_metrics.py::TestCacheMetrics::test_get_efficiency_score_low_hit_rate # cluster: known survey failure
+tests/test_cli_commands.py::test_analyze_command_success # cluster: CLI output/command drift
+tests/test_cli_experiment_command.py::test_behavior_experiment_command_writes_output # cluster: CLI output/command drift
+tests/test_core_engine.py::TestDecisionPersistence::test_analyze_asset_end_to_end_debate_smoke_persists_spine_fields # cluster: debate/decision policy action compatibility
+tests/test_correlation_analyzer.py::TestCorrelationAnalyzer::test_calculate_pearson_correlation_no_correlation # cluster: provider/platform payload shape drift
+tests/test_data_providers_comprehensive.py::TestAlphaVantageProvider::test_circuit_breaker_opens_on_failures # cluster: provider/platform payload shape drift
+tests/test_data_providers_fixed_v2.py::TestAlphaVantageProviderFixed::test_get_market_data_success_crypto # cluster: provider/platform payload shape drift
+tests/test_debate_policy_actions.py::test_debate_policy_action_close_preserves_none_legacy_compatibility # cluster: debate/decision policy action compatibility
+tests/test_decision_engine_helpers.py::TestCalculatePositionSizingParams::test_hold_without_position_no_sizing # cluster: risk/position sizing semantics
+tests/test_decision_engine_logic.py::TestPositionSizing::test_calculate_position_size_zero_stop_loss # cluster: risk/position sizing semantics
+tests/test_decision_round_trip_canonicalization.py::test_canonical_decision_fields_round_trip_by_shape[_policy_trace_fixture-expected_lineage_fields4] # cluster: debate/decision policy action compatibility
+tests/test_decision_store_policy_trace.py::test_decision_store_round_trips_policy_trace # cluster: debate/decision policy action compatibility
+tests/test_decision_store_policy_trace.py::test_decision_store_legacy_records_without_policy_trace_still_load # cluster: debate/decision policy action compatibility
+tests/test_e2e_first_profitable_trade.py::TestFirstProfitableTrade::test_execute_profitable_trade_scenario # cluster: profitability/e2e expectation drift
+tests/test_fragile_seam_invariants.py::TestNormalizeLearningProviderDecisions::test_judge_only_provider_decisions_reconstructed_from_roles # cluster: debate/decision policy action compatibility
+tests/test_fragile_seam_invariants.py::TestNormalizeLearningProviderDecisions::test_role_without_provider_key_skipped # cluster: debate/decision policy action compatibility
+tests/test_frontend_bot_integration.py::TestFrontendBotIntegration::test_frontend_starts_bot_and_executes_trade # cluster: profitability/e2e expectation drift
+tests/test_jwt_authentication.py::TestJWTSecurityFeatures::test_algorithm_confusion_attack_prevented # cluster: auth/security behavior drift
+tests/test_kelly_criterion_division_by_zero.py::TestDivisionByZeroFixes::test_position_size_with_zero_payoff_ratio # cluster: risk/position sizing semantics
+tests/test_monitoring_integration.py::test_decision_generation_with_monitoring # cluster: API/core drift
+tests/test_platform_error_handling.py::TestMockPlatformErrorSimulation::test_mock_platform_zero_error_rate # cluster: provider/platform payload shape drift
+tests/test_portfolio_retrievers.py::TestMockPortfolioRetriever::test_assemble_result_creates_complete_breakdown # cluster: provider/platform payload shape drift
+tests/test_portfolio_retrievers.py::TestMockPortfolioRetriever::test_get_portfolio_breakdown_orchestrates_steps # cluster: provider/platform payload shape drift
+tests/test_positions_cli.py::test_positions_cli_command_single_platform # cluster: CLI output/command drift
+tests/test_positions_cli.py::test_positions_cli_command_unified_platform # cluster: CLI output/command drift
+tests/test_risk_gatekeeper.py::TestMarketScheduleValidation::test_forex_not_blocked_when_closed # cluster: risk/position sizing semantics
+tests/test_short_backtesting.py::TestShortBacktestingIntegration::test_backtest_with_short_positions # cluster: known survey failure
+tests/test_threshold_avoidance.py::test_load_decision_records_report_counts_unreadable_files # cluster: known survey failure
+tests/test_tradingagentconfig_polymorphism.py::TestPositionSizingWithPolymorphicConfig::test_position_sizing_with_object_agent_config # cluster: risk/position sizing semantics
+tests/test_tradingagentconfig_polymorphism.py::TestPositionSizingWithPolymorphicConfig::test_position_sizing_uses_correct_risk_percentage # cluster: risk/position sizing semantics
+tests/test_var_no_active_platforms.py::test_var_with_no_active_platforms_does_not_log_dual_portfolio # cluster: risk/position sizing semantics
+tests/test_webhook_delivery.py::test_webhook_delivery_retry_on_failure # cluster: webhook retry behavior

--- a/tests/test_core_risk_and_health.py
+++ b/tests/test_core_risk_and_health.py
@@ -69,6 +69,7 @@ def engine_for_health_checks(minimal_config):
 class TestAgentReadinessValidation:
     """Test agent readiness validation before autonomous trading."""
 
+    @pytest.mark.external_service
     def test_validate_agent_readiness_success(self, engine_for_health_checks):
         """Test successful readiness validation."""
         is_ready, errors = engine_for_health_checks.validate_agent_readiness()

--- a/tests/test_decision_engine_logic.py
+++ b/tests/test_decision_engine_logic.py
@@ -436,6 +436,7 @@ class TestDecisionGeneration:
 class TestEnsembleIntegration:
     """Test ensemble manager integration (mocked)."""
 
+    @pytest.mark.external_service
     @pytest.mark.asyncio
     async def test_ensemble_decision_mocked(
         self, ensemble_engine, sample_market_data, sample_balance

--- a/tests/test_thr227_ffe_initialization.py
+++ b/tests/test_thr227_ffe_initialization.py
@@ -13,6 +13,8 @@ import pytest
 from finance_feedback_engine.core import FinanceFeedbackEngine
 from finance_feedback_engine.utils.config_loader import load_config
 
+pytestmark = pytest.mark.external_service
+
 
 def test_ffe_initializes_automatically():
     """Test that FFE initializes critical components in __init__."""


### PR DESCRIPTION
## Why

PR #86 / Plane #90 could not regain a useful merge gate while the backend suite was structurally red and timing out. GitHub #88 Phase 2 survey isolated a clean fast-lane candidate set plus known debt:

- Phase 2 survey: https://github.com/Grovex-Tech-Solutions/finance_feedback_engine/issues/88#issuecomment-4340799427
- Tier validation: https://github.com/Grovex-Tech-Solutions/finance_feedback_engine/issues/88#issuecomment-4340860192

The prior required backend gate had 147+ visible failures / 26 errors in CI diagnostics and then the full survey showed the current suite shape still has concentrated structural failures and timeout clusters. This PR restores a required merge gate by quarantining known structural debt and preserving otherwise-clean files in the fast lane.

## What changed

- Split `.github/workflows/ci.yml` into:
  - `tests-fast` — required merge-gate candidate, runs all non-quarantined tests with `pytest-xdist -n auto`, coverage, timeout protection, and Tier 2 known failures applied as xfail.
  - `tests-slow` — non-blocking slow lane for the 26 Tier 1 quarantined files, `continue-on-error: true`, 60m job budget.
- Added `tests/known_failing.txt` with 46 Tier 2 nodeids from the survey: individual failures in otherwise-clean files.
- Added a `tests/conftest.py` collection hook that applies non-strict `xfail` markers from `tests/known_failing.txt` without editing individual test files.

## Required repo-admin follow-up before relying on this gate

After this PR lands, update branch protection to require **only `tests-fast`** for the merge gate. `tests-slow` is intentionally non-blocking/red-allowed while the cluster tickets are burned down.

## Plane tracking tickets

Umbrella Tier 2 xfail debt:
- FINANCEFEE-99 — Tier 2 xfail debt — fast-lane known-failing tests.

Tier 1 cluster tickets:
- FINANCEFEE-100 — TestClient/lifespan teardown leak
- FINANCEFEE-101 — test_core_* regression cluster
- FINANCEFEE-102 — test_coinbase_platform_comprehensive failure cluster
- FINANCEFEE-103 — test_config_editor_telegram_validation 89% failure
- FINANCEFEE-104 — test_observability_integration fixture errors
- FINANCEFEE-105 — External-data / long-running timeouts
- FINANCEFEE-106 — Misc ≥3-failure clusters

## Validation before push

- `tests/known_failing.txt` generated from the Phase 2 survey failure summary, excluding all 26 Tier 1 quarantined files.
- All Tier 1 and Tier 2 file paths exist on the branch.
- `tests/conftest.py` compiles with `python -m py_compile`.
- Workflow YAML parses successfully.


## Fast-lane marker convention

Fast-lane uses the existing marker exclusion:

```bash
-m "not external_service and not slow and not benchmark"
```

Tests requiring external services should carry the appropriate existing project marker, usually `@pytest.mark.external_service`; otherwise they run in fast-lane by default. The env-dependent marker fixes and the hard-coded path fix in this PR are part of restoring that convention's health, not a new policy.

Coverage XML is still emitted from `tests-fast`, but the prior `--cov-fail-under=70` gate is removed while the suite is split. Follow-up: FINANCEFEE-107 — Restore coverage gating after lane split — needs cross-lane coverage merge OR fast-lane-only target.

## Notes

This PR intentionally does not fix the quarantined tests. The goal is to restore a stable required merge gate first; follow-up tickets then migrate files from Tier 1 → Tier 2/Tier 3 and remove Tier 2 entries as fixes land.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored CI pipeline into fast and slow test lanes for quicker feedback on code changes
  * Enhanced test infrastructure to properly mark and handle known failing tests without blocking the build process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
