### PR TITLE
fix: Plane #88 debate latency prompt cut

### DIFF
--- a/finance_feedback_engine/decision_engine/ai_decision_manager.py
+++ b/finance_feedback_engine/decision_engine/ai_decision_manager.py
@@ -888,13 +888,13 @@ Data Quality: <good|degraded|stale>
             debate_timing["bull_s"] = round(float(bull_elapsed), 4)
         bull_prompt_chars = bull_result.get("prompt_chars")
         if bull_prompt_chars is not None:
-            debate_timing["bull_prompt_chars"] = float(bull_prompt_chars)
+            debate_timing["bull_prompt_chars"] = int(bull_prompt_chars)
         bear_elapsed = bear_result.get("elapsed_s")
         if bear_elapsed is not None:
             debate_timing["bear_s"] = round(float(bear_elapsed), 4)
         bear_prompt_chars = bear_result.get("prompt_chars")
         if bear_prompt_chars is not None:
-            debate_timing["bear_prompt_chars"] = float(bear_prompt_chars)
+            debate_timing["bear_prompt_chars"] = int(bear_prompt_chars)
         bull_case = bull_result["case"]
         failed_debate_providers.extend(bull_result.get("failed", []))
         bear_case = bear_result["case"]

--- a/finance_feedback_engine/decision_engine/ai_decision_manager.py
+++ b/finance_feedback_engine/decision_engine/ai_decision_manager.py
@@ -418,7 +418,7 @@ class AIDecisionManager:
             prompt_chars,
             bool(failed),
         )
-        return {"case": case, "failed": failed, "elapsed_s": elapsed_s}
+        return {"case": case, "failed": failed, "elapsed_s": elapsed_s, "prompt_chars": prompt_chars}
 
     def _truncate_for_judge(self, reasoning: Optional[str]) -> str:
         if not reasoning:
@@ -886,9 +886,15 @@ Keep the total reasoning concise. Do not add extra sections or long prose.
         bull_elapsed = bull_result.get("elapsed_s")
         if bull_elapsed is not None:
             debate_timing["bull_s"] = round(float(bull_elapsed), 4)
+        bull_prompt_chars = bull_result.get("prompt_chars")
+        if bull_prompt_chars is not None:
+            debate_timing["bull_prompt_chars"] = float(bull_prompt_chars)
         bear_elapsed = bear_result.get("elapsed_s")
         if bear_elapsed is not None:
             debate_timing["bear_s"] = round(float(bear_elapsed), 4)
+        bear_prompt_chars = bear_result.get("prompt_chars")
+        if bear_prompt_chars is not None:
+            debate_timing["bear_prompt_chars"] = float(bear_prompt_chars)
         bull_case = bull_result["case"]
         failed_debate_providers.extend(bull_result.get("failed", []))
         bear_case = bear_result["case"]
@@ -906,7 +912,8 @@ Keep the total reasoning concise. Do not add extra sections or long prose.
             # Add judge-specific instructions with bull/bear context
             _timing_started = time.perf_counter()
             judge_prompt = self._build_judge_prompt(prompt, bull_case, bear_case)
-            
+            debate_timing["judge_prompt_chars"] = float(len(judge_prompt))
+
             debate_timing["judge_prompt_build_s"] = round(time.perf_counter() - _timing_started, 4)
             _timing_started = time.perf_counter()
             judge_decision = await self._query_single_provider(

--- a/finance_feedback_engine/decision_engine/ai_decision_manager.py
+++ b/finance_feedback_engine/decision_engine/ai_decision_manager.py
@@ -806,9 +806,10 @@ Confidence calibration:
 - 70-79 = borderline or incomplete setup; below the intended strict judged-open entry bar
 - 60-69 = weak/speculative lean; monitor is usually better than acting now
 - 0-59 = non-actionable, degraded, stale, or HOLD-quality setup
+- Operational anchor: 80-89 should usually map to Actionability=actionable_now; 70-79 to monitor; 0-59 to no_trade or HOLD-quality setups.
 - Do not use 75 as a generic synonym for "high confidence".
 
-In reasoning, use this exact mini-structure, keeping each line short and concrete:
+Reasoning (concise — no extra sections, no long prose):
 Thesis: <one short bullish thesis>
 Actionability: <actionable_now|monitor|no_trade>
 Trend Alignment: <aligned|countertrend|mixed>
@@ -818,7 +819,6 @@ Top Evidence:
 Major Risk: <short biggest reason the bullish case could fail>
 Thesis Breaker: <short invalidating condition>
 Data Quality: <good|degraded|stale>
-Keep the total reasoning concise. Do not add extra sections or long prose.
 """
 
         _bear_prompt_suffix = f"""
@@ -858,9 +858,10 @@ Confidence calibration:
 - 70-79 = borderline or incomplete setup; below the intended strict judged-open entry bar
 - 60-69 = weak/speculative lean; monitor is usually better than acting now
 - 0-59 = non-actionable, degraded, stale, or HOLD-quality setup
+- Operational anchor: 80-89 should usually map to Actionability=actionable_now; 70-79 to monitor; 0-59 to no_trade or HOLD-quality setups.
 - Do not use 75 as a generic synonym for "high confidence".
 
-In reasoning, use this exact mini-structure, keeping each line short and concrete:
+Reasoning (concise — no extra sections, no long prose):
 Thesis: <one short bearish thesis>
 Actionability: <actionable_now|monitor|no_trade>
 Trend Alignment: <aligned|countertrend|mixed>
@@ -870,7 +871,6 @@ Top Evidence:
 Major Risk: <short biggest reason the bearish case could fail>
 Thesis Breaker: <short invalidating condition>
 Data Quality: <good|degraded|stale>
-Keep the total reasoning concise. Do not add extra sections or long prose.
 """
 
         _debate_parallel_started = time.perf_counter()

--- a/tests/decision_engine/test_debate_prompt_contracts.py
+++ b/tests/decision_engine/test_debate_prompt_contracts.py
@@ -35,6 +35,8 @@ def test_debate_prompts_include_structured_reasoning_contracts():
     assert 'Top Evidence:' in bull_prompt
     assert 'Data Quality:' in bull_prompt
     assert 'Confidence calibration:' in bull_prompt
+    assert 'Operational anchor: 80-89 should usually map to Actionability=actionable_now; 70-79 to monitor; 0-59 to no_trade or HOLD-quality setups.' in bull_prompt
+    assert 'Reasoning (concise — no extra sections, no long prose):' in bull_prompt
     assert 'Do not use 75 as a generic synonym for "high confidence".' in bull_prompt
 
     assert 'Thesis:' in bear_prompt
@@ -42,6 +44,8 @@ def test_debate_prompts_include_structured_reasoning_contracts():
     assert 'Trend Alignment:' in bear_prompt
     assert 'Top Evidence:' in bear_prompt
     assert 'Data Quality:' in bear_prompt
+    assert 'Operational anchor: 80-89 should usually map to Actionability=actionable_now; 70-79 to monitor; 0-59 to no_trade or HOLD-quality setups.' in bear_prompt
+    assert 'Reasoning (concise — no extra sections, no long prose):' in bear_prompt
 
     assert 'MANDATORY HOLD CONDITIONS' in judge_prompt
     assert 'HOLD is an active decision, not the default fallback' in judge_prompt
@@ -211,6 +215,7 @@ LONG TAIL SECTION:
     assert "ALLOWED POLICY ACTIONS:" in compact
     assert "MARKET DATA:" in compact
     assert "MARKET BRIEF:" in compact
+    assert "RISK MANAGEMENT & POSITION CONTEXT:" not in compact
     assert len(compact) < len(full_prompt)
 
 
@@ -321,6 +326,8 @@ Open positions: none
     assert "MULTI-TIMEFRAME TREND ANALYSIS:" in compact
     assert "RISK MANAGEMENT & POSITION CONTEXT:" in compact
     assert "MARKET BRIEF:" in compact
+    assert "POSITION STATE:" not in compact
+    assert "MARKET DATA:" not in compact
     assert len(compact) >= 300
     assert len(compact) <= 1200
 
@@ -395,8 +402,8 @@ Key Question: Should we adjust the existing long position given the overbought R
 def test_role_prompts_request_concise_reasoning_and_two_evidence_points():
     source = (Path(__file__).resolve().parents[2] / 'finance_feedback_engine/decision_engine/ai_decision_manager.py').read_text()
 
-    assert 'keeping each line short and concrete' in source
-    assert 'Keep the total reasoning concise. Do not add extra sections or long prose.' in source
+    assert 'Reasoning (concise — no extra sections, no long prose):' in source
+    assert 'Operational anchor: 80-89 should usually map to Actionability=actionable_now; 70-79 to monitor; 0-59 to no_trade or HOLD-quality setups.' in source
     assert '1. <best bullish evidence>' in source
     assert '2. <second bullish evidence>' in source
     assert '3. <third bullish evidence>' not in source


### PR DESCRIPTION
## Summary
- cherry-pick Plane #88 per-stage debate prompt timing instrumentation from `549d9e0d`
- apply the corrected 1+3 debate prompt cut with restored confidence-band operational anchors and the exact concise reasoning header
- update the prompt contract test to assert the new prose pattern and verify the compact-prompt header paths stay mutually exclusive

## Validation
- `.venv/bin/pytest tests/decision_engine/test_debate_prompt_contracts.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Debate prompts now include an explicit "Operational anchor" mapping confidence to recommended actions.
  * Reasoning format standardized to a single concise header for clearer explanations.

* **Improvements**
  * Expanded telemetry to report prompt character counts (overall and per debate role) alongside timing and outcome metrics.

* **Tests**
  * Validation updated to enforce the new prompt wording and compact-debate formatting expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->